### PR TITLE
allow json schema with arrays of objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,12 @@ self.methods_by_type = {
 
 It also can generate arrays like `std::array<T, Size>` if `T` is a simple type from above.
 
+Array of custom (user-defined) types is also supported but has strict restriction.
+All subobjects of the same array **MUST** have the same structure i.e, all their **keys are SAME** (so they can be converted to the objects of the same type). Of course values can be different.
+
+Example:
+...
+
 ### Names
 
 Naming conventions? Thrown away...

--- a/res/example_2.json
+++ b/res/example_2.json
@@ -1,20 +1,20 @@
 {
   "widget": {
-  "debug": "on",
-  "window": {
+    "debug": "on",
+    "window": {
       "title": "Sample Konfabulator Widget",
       "name": "main_window",
       "width": 500,
       "height": 500
-  },
-  "image": { 
+    },
+    "image": { 
       "src": "Images/Sun.png",
       "name": "sun1",
       "h_offset": 250,
       "v_offset": 250,
       "alignment": "center"
-  },
-  "text": {
+    },
+    "text": {
       "data": "Click Here",
       "size": 36,
       "style": "bold",

--- a/res/example_4.json
+++ b/res/example_4.json
@@ -1,0 +1,40 @@
+{
+  "menu": {  
+    "id": "file",  
+    "value": "File",  
+    "popup": {  
+      "menuitem": [  
+        { 
+            "value": [
+                { 
+                    "v1":"New",  
+                    "v2":"Old",
+                    "v3":"Update"
+                },
+                { 
+                    "v1":"Key1",  
+                    "v2":"Key2",
+                    "v3":"Key3"
+                }
+            ],
+            "onclick": "CreateDoc()"
+        },
+        { 
+            "value": [
+                { 
+                    "v1":"New1",  
+                    "v2":"Old1",
+                    "v3":"Update1"
+                },
+                { 
+                    "v1":"Key11",  
+                    "v2":"Key22",
+                    "v3":"Key33"
+                }
+            ],
+            "onclick": "CreateDoc()"
+        }
+      ]  
+    }  
+  }
+}


### PR DESCRIPTION
Allow json schema with arrays of objects. It's translated to `std::array<T, size> ` where `T` is a user-defined type.
Do note that this feature has a harsh restriction on json schema: json objects in array must have the same structure (key values). This is true even for nested ones.

close #2 